### PR TITLE
Fix Dockerfile deps and robust entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,10 +43,8 @@ WORKDIR /opt/turtlebot3_ws
 RUN mkdir src
 COPY . src/
 
-# 6) Bring in your package-specific rosdep script
+# 6) Bring in turtlebot3_autorace (for camera calibration launch files)
 RUN git clone https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git src/turtlebot3_autorace
-COPY moi_exp_lite/rosdep_install.sh /rosdep_install.sh
-RUN chmod +x /rosdep_install.sh
 
 
 # Remove ament_python from package.xml so rosdep won't choke on it
@@ -54,17 +52,19 @@ RUN sed -i '/<buildtool_depend>ament_python<\/buildtool_depend>/d' src/moi_exp_l
  && sed -i '/<depend>ament_python<\/depend>/d'          src/moi_exp_lite/package.xml
 
 # 7) Install all dependencies & build
-# 7) Install all dependencies & build
 RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
-    # a) deps for moi_exp_lite
-    cd src/moi_exp_lite && /rosdep_install.sh && cd ../.. && \
-    # b) rest of workspace deps (skip problematic keys) + build
+    # a) deps for moi_exp_lite (skip unavailable camera package)
     rosdep update && \
+    rosdep install --from-paths src/moi_exp_lite \
+                   --ignore-src \
+                   --skip-keys turtlebot3_autorace_camera \
+                   -y && \
+    # b) rest of workspace deps (skip problematic keys) + build
     rosdep install --from-paths src \
                    --ignore-src \
                    -r \
                    --skip-keys ament_python \
-                   --skip-keys turtlebot3-autorace-camera \
+                   --skip-keys turtlebot3_autorace_camera \
                    -y && \
     colcon build --symlink-install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # 3) GUI extras (X11 apps)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      x11-apps \
+      x11-apps xauth \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ensure GUI apps like Gazebo can connect to the host display
+ENV QT_X11_NO_MITSHM=1
 
 # 4) Python libs you need
 RUN pip3 install \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# Allow GUI applications if available
+export QT_X11_NO_MITSHM=${QT_X11_NO_MITSHM:-1}
+if [ -n "$DISPLAY" ] && command -v xauth >/dev/null; then
+  XAUTH_FILE=${XAUTHORITY:-$HOME/.Xauthority}
+  if [ ! -f "$XAUTH_FILE" ]; then
+    xauth generate "$DISPLAY" . trusted
+    export XAUTHORITY="$XAUTH_FILE"
+  fi
+fi
+
 # Source ROS 2 and the built workspace if present
 source /opt/ros/${ROS_DISTRO}/setup.bash
 if [ -f /opt/turtlebot3_ws/install/setup.bash ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-# Source ROS 2 and user workspace
-source /opt/ros/${ROS_DISTRO}/setup.bash
-source /opt/turtlebot3_ws/install/setup.bash
+set -e
 
-# Ready for simulation: user can launch Gazebo or RViz as needed
+# Source ROS 2 and the built workspace if present
+source /opt/ros/${ROS_DISTRO}/setup.bash
+if [ -f /opt/turtlebot3_ws/install/setup.bash ]; then
+  source /opt/turtlebot3_ws/install/setup.bash
+fi
+
+# Hand off to whatever the user specified
 exec "$@"


### PR DESCRIPTION
## Summary
- avoid failing rosdep install in Docker build
- skip unavailable turtlebot3 camera package when resolving dependencies
- make entrypoint more robust

## Testing
- `bash -n docker/entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68762ada94b483239ffe3c4c1116a36c